### PR TITLE
Show full assignee name in board avatars

### DIFF
--- a/app/Template/board/task_avatar.php
+++ b/app/Template/board/task_avatar.php
@@ -1,11 +1,9 @@
 <?php if (! empty($task['owner_id'])): ?>
 <div class="task-board-avatars">
-    <span
-        <?php if ($this->user->hasProjectAccess('TaskModificationController', 'edit', $task['project_id'])): ?>
-        class="task-board-assignee task-board-change-assignee"
-        data-url="<?= $this->url->href('TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>">
+    <?php if ($this->user->hasProjectAccess('TaskModificationController', 'edit', $task['project_id'])): ?>
+    <span class="task-board-change-assignee" data-url="<?= $this->url->href('TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>">
     <?php else: ?>
-        class="task-board-assignee">
+    <span>
     <?php endif ?>
         <?= $this->avatar->small(
             $task['owner_id'],

--- a/app/Template/board/task_private.php
+++ b/app/Template/board/task_private.php
@@ -46,12 +46,6 @@
                     <strong><?= '#'.$task['id'] ?></strong>
                 <?php endif ?>
 
-                <?php if (! empty($task['owner_id'])): ?>
-                    <span class="task-board-assignee">
-                        <?= $this->text->e($task['assignee_name'] ?: $task['assignee_username']) ?>
-                    </span>
-                <?php endif ?>
-
                 <?= $this->render('board/task_avatar', array('task' => $task)) ?>
             </div>
 

--- a/app/Template/board/task_public.php
+++ b/app/Template/board/task_public.php
@@ -2,12 +2,6 @@
     <div class="task-board-header">
         <?= $this->url->link('#'.$task['id'], 'TaskViewController', 'readonly', array('task_id' => $task['id'], 'token' => $project['token'])) ?>
 
-        <?php if (! empty($task['owner_id'])): ?>
-            <span class="task-board-assignee">
-                <?= $this->text->e($task['assignee_name'] ?: $task['assignee_username']) ?>
-            </span>
-        <?php endif ?>
-
         <?= $this->render('board/task_avatar', array('task' => $task)) ?>
     </div>
 

--- a/app/User/Avatar/LetterAvatarProvider.php
+++ b/app/User/Avatar/LetterAvatarProvider.php
@@ -30,18 +30,17 @@ class LetterAvatarProvider extends Base implements AvatarProviderInterface
      */
     public function render(array $user, $size)
     {
-        $initials = $this->helper->user->getInitials($user['name'] ?: $user['username']);
         $rgb = $this->getBackgroundColor($user['name'] ?: $user['username']);
-        $name = $this->helper->text->e($user['name'] ?: $user['username']);
+        $label = $this->helper->text->e($user['name'] ?: $user['username']);
 
         return sprintf(
             '<div class="avatar-letter" style="background-color: rgb(%d, %d, %d)" title="%s" role="img" aria-label="%s">%s</div>',
             $rgb[0],
             $rgb[1],
             $rgb[2],
-            $name,
-            $name,
-            $this->helper->text->e($initials)
+            $label,
+            $label,
+            $label
         );
     }
 

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -34,7 +34,7 @@ class UserMentionFormatterTest extends Base
             ),
             array(
                 'value' => 'somebody',
-                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: rgb(191, 210, 121)" title="somebody" role="img" aria-label="somebody">S</div></div> somebody',
+                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: rgb(191, 210, 121)" title="somebody" role="img" aria-label="somebody">somebody</div></div> somebody',
             ),
         );
 

--- a/tests/units/User/Avatar/LetterAvatarProviderTest.php
+++ b/tests/units/User/Avatar/LetterAvatarProviderTest.php
@@ -24,7 +24,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'Kanboard Admin', 'username' => 'bob', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(120, 83, 58)" title="Kanboard Admin" role="img" aria-label="Kanboard Admin">KA</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(120, 83, 58)" title="Kanboard Admin" role="img" aria-label="Kanboard Admin">Kanboard Admin</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -32,7 +32,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => '', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(134, 45, 132)" title="admin" role="img" aria-label="admin">A</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(134, 45, 132)" title="admin" role="img" aria-label="admin">admin</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -40,7 +40,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'ü', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(62, 147, 31)" title="ü" role="img" aria-label="ü">Ü</div>';
+        $expected = '<div class="avatar-letter" style="background-color: rgb(62, 147, 31)" title="ü" role="img" aria-label="ü">ü</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 }


### PR DESCRIPTION
## Summary
- Remove assignee name label from board cards
- Replace board avatar initials with full user names
- Update unit tests for full-name avatars

## Testing
- `php -l app/Template/board/task_private.php app/Template/board/task_public.php app/Template/board/task_avatar.php app/User/Avatar/LetterAvatarProvider.php tests/units/User/Avatar/LetterAvatarProviderTest.php tests/units/Formatter/UserMentionFormatterTest.php`
- `vendor/bin/phpunit tests/units/User/Avatar/LetterAvatarProviderTest.php tests/units/Formatter/UserMentionFormatterTest.php` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e21eaf2c8324bec55e674054b01d