### PR TITLE
Refactor task card layout to show category and assignee in header

### DIFF
--- a/app/Template/board/task_footer.php
+++ b/app/Template/board/task_footer.php
@@ -1,4 +1,9 @@
-<?php if (! empty($task['category_id'])): ?>
+<?php
+    // Allow callers to hide the category section when it is rendered elsewhere
+    $include_category = $include_category ?? true;
+?>
+
+<?php if ($include_category && ! empty($task['category_id'])): ?>
 <div class="task-board-category-container task-board-category-container-color">
     <span class="task-board-category category-<?= $this->text->e($task['category_name']) ?> <?= $task['category_color_id'] ? "color-{$task['category_color_id']}" : '' ?>">
         <?php if ($not_editable): ?>

--- a/app/Template/board/task_private.php
+++ b/app/Template/board/task_private.php
@@ -37,13 +37,24 @@
         <div class="task-board-expanded">
             <div class="task-board-saving-icon" style="display: none;"><i class="fa fa-spinner fa-pulse fa-2x"></i></div>
             <div class="task-board-header">
-                <?php if ($this->user->hasProjectAccess('TaskModificationController', 'edit', $task['project_id'])): ?>
-                    <?= $this->render('task/dropdown', array('task' => $task, 'redirect' => 'board')) ?>
-                    <?php if ($this->projectRole->canUpdateTask($task)): ?>
-                        <?= $this->modal->large('edit', '', 'TaskModificationController', 'edit', array('task_id' => $task['id'])) ?>
-                    <?php endif ?>
-                <?php else: ?>
-                    <strong><?= '#'.$task['id'] ?></strong>
+                <strong><?= '#'.$task['id'].' ' ?></strong>
+
+                <?php if (! empty($task['category_id'])): ?>
+                    <span class="task-board-category category-<?= $this->text->e($task['category_name']) ?> <?= $task['category_color_id'] ? "color-{$task['category_color_id']}" : '' ?>">
+                        <?php if ($this->user->hasProjectAccess('TaskModificationController', 'edit', $task['project_id'])): ?>
+                            <?= $this->url->link(
+                                $this->text->e($task['category_name']),
+                                'TaskModificationController',
+                                'edit',
+                                array('task_id' => $task['id']),
+                                false,
+                                'js-modal-large',
+                                t('Change category')
+                            ) ?>
+                        <?php else: ?>
+                            <?= $this->text->e($task['category_name']) ?>
+                        <?php endif ?>
+                    </span>
                 <?php endif ?>
 
                 <?= $this->render('board/task_avatar', array('task' => $task)) ?>
@@ -59,6 +70,7 @@
                 'task' => $task,
                 'not_editable' => $not_editable,
                 'project' => $project,
+                'include_category' => false,
             )) ?>
         </div>
     <?php endif ?>

--- a/app/Template/board/task_public.php
+++ b/app/Template/board/task_public.php
@@ -1,6 +1,12 @@
 <div class="task-board color-<?= $task['color_id'] ?> <?= $task['date_modification'] > time() - $board_highlight_period ? 'task-board-recent' : '' ?>">
     <div class="task-board-header">
-        <?= $this->url->link('#'.$task['id'], 'TaskViewController', 'readonly', array('task_id' => $task['id'], 'token' => $project['token'])) ?>
+        <strong><?= '#'.$task['id'].' ' ?></strong>
+
+        <?php if (! empty($task['category_id'])): ?>
+            <span class="task-board-category category-<?= $this->text->e($task['category_name']) ?> <?= $task['category_color_id'] ? "color-{$task['category_color_id']}" : '' ?>">
+                <?= $this->text->e($task['category_name']) ?>
+            </span>
+        <?php endif ?>
 
         <?= $this->render('board/task_avatar', array('task' => $task)) ?>
     </div>
@@ -15,5 +21,6 @@
         'task' => $task,
         'not_editable' => $not_editable,
         'project' => $project,
+        'include_category' => false,
     )) ?>
 </div>


### PR DESCRIPTION
## Summary
- Show task ID, category, and assignee avatar together in task board header
- Allow task footer to optionally hide category section so it can be rendered elsewhere
- Adjust public and private board templates to use new header layout

## Testing
- `make test-sqlite` *(fails: ./vendor/bin/phpunit: No such file or directory)*
- `composer install --no-interaction` *(fails: unable to access packages, CONNECT tunnel failed response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b131b373908324aef8ad1c7d3166ef