### PR TITLE
Lighten project type and tag backgrounds

### DIFF
--- a/app/Model/ColorModel.php
+++ b/app/Model/ColorModel.php
@@ -218,8 +218,18 @@ class ColorModel extends Base
         $buffer = '';
 
         foreach ($this->default_colors as $color => $values) {
-            $buffer .= '.task-board.color-'.$color.', .task-summary-container.color-'.$color.', .color-picker-square.color-'.$color.', .task-board-category.color-'.$color.', .table-list-category.color-'.$color.', .task-tag.color-'.$color.' {';
+            $lighterBackground = $this->lightenColor($values['background'], 0.25);
+
+            $buffer .= '.task-board.color-'.$color.', .task-summary-container.color-'.$color.', .color-picker-square.color-'.$color.', .task-board-category.color-'.$color.', .table-list-category.color-'.$color.' {';
             $buffer .= 'background-color: '.$values['background'].';';
+            $buffer .= 'border-color: '.$values['border'];
+            $buffer .= '}';
+            $buffer .= '.task-tag.color-'.$color.' {';
+            $buffer .= 'background-color: '.$lighterBackground.';';
+            $buffer .= 'border-color: '.$values['border'];
+            $buffer .= '}';
+            $buffer .= '.task-board.color-'.$color.' .task-board-project, .task-board.color-'.$color.' .task-tags .task-tag {';
+            $buffer .= 'background-color: '.$lighterBackground.';';
             $buffer .= 'border-color: '.$values['border'];
             $buffer .= '}';
             $buffer .= 'td.color-'.$color.' { background-color: '.$values['background'].'}';
@@ -227,5 +237,47 @@ class ColorModel extends Base
         }
 
         return $buffer;
+    }
+
+    /**
+     * Lighten an RGB or hex color
+     *
+     * @access protected
+     * @param  string  $color
+     * @param  float   $percentage
+     * @return string
+     */
+    protected function lightenColor($color, $percentage)
+    {
+        $percentage = max(0, min(1, $percentage));
+
+        if (strpos($color, 'rgb') === 0) {
+            preg_match_all('/\d+/', $color, $matches);
+            $components = array_map('intval', array_slice($matches[0], 0, 3));
+        } else {
+            $hex = ltrim($color, '#');
+
+            if (strlen($hex) === 3) {
+                $hex = sprintf('%s%s%s', $hex[0].$hex[0], $hex[1].$hex[1], $hex[2].$hex[2]);
+            }
+
+            $components = array(
+                hexdec(substr($hex, 0, 2)),
+                hexdec(substr($hex, 2, 2)),
+                hexdec(substr($hex, 4, 2)),
+            );
+        }
+
+        if (count($components) !== 3) {
+            return $color;
+        }
+
+        foreach ($components as &$component) {
+            $component = (int) round($component + (255 - $component) * $percentage);
+            $component = max(0, min(255, $component));
+        }
+        unset($component);
+
+        return sprintf('rgb(%d, %d, %d)', $components[0], $components[1], $components[2]);
     }
 }

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -89,5 +89,7 @@ class ColorModelTest extends Base
         $css = $colorModel->getCss();
 
         $this->assertStringStartsWith('.task-board.color-yellow', $css);
+        $this->assertStringContainsString('.task-board.color-yellow .task-board-project, .task-board.color-yellow .task-tags .task-tag {background-color: rgb(248, 249, 211);border-color: rgb(223, 227, 45);}', $css);
+        $this->assertStringContainsString('.task-tag.color-yellow {background-color: rgb(248, 249, 211);border-color: rgb(223, 227, 45);}', $css);
     }
 }


### PR DESCRIPTION
## Summary
- generate lighter backgrounds for project indicators and task tags based on the card color palette
- add a color lightening helper that handles both rgb and hex definitions to keep styling consistent
- extend the color model unit test to cover the new CSS output

## Testing
- php -l app/Model/ColorModel.php
- php -l tests/units/Model/ColorModelTest.php
- make test-sqlite *(fails: phpunit not installed; composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1047569c83248e223de7d7cad4cb