### PR TITLE
Adjust Oxygen header layout for large logo

### DIFF
--- a/plugins/Oxygen/Assets/css/oxygen.css
+++ b/plugins/Oxygen/Assets/css/oxygen.css
@@ -28,10 +28,33 @@ th,td {
 	padding: 10px;
 }
 header {
-	border-bottom: none;
-	box-shadow: 0px 1px 3px 0 rgba(46,61,73,.12);
-	padding: 15px 10px;
-	margin-bottom: 15px;
+        border-bottom: none;
+        box-shadow: 0px 1px 3px 0 rgba(46,61,73,.12);
+        padding: 15px 10px;
+        margin-bottom: 15px;
+}
+.logo-image {
+        display: block;
+        height: 75px;
+        width: auto;
+}
+header .title-container h1 {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+}
+header .title-container h1 .logo,
+header .title-container h1 .title {
+        display: flex;
+        align-items: center;
+}
+header .title-container h1 .logo {
+        flex-shrink: 0;
+}
+header .title-container h1 .title {
+        gap: 0.4em;
+        min-width: 0;
 }
 .header img {
   float: left;


### PR DESCRIPTION
## Summary
- style the custom logo image with a fixed 75px height while keeping its width automatic
- use flexbox on the header title container so the project title stays beside and vertically centered with the logo

## Testing
- not run (css change)


------
https://chatgpt.com/codex/tasks/task_e_68cb6b109cc48324900c4fe0dbe62c25