### PR TITLE
Add deep purple color variant styling

### DIFF
--- a/app/Model/ColorModel.php
+++ b/app/Model/ColorModel.php
@@ -34,10 +34,20 @@ class ColorModel extends Base
             'background' => 'rgb(189, 244, 203)',
             'border' => 'rgb(74, 227, 113)',
         ),
+        'dirty_green' => array(
+            'name' => 'Dirty Green',
+            'background' => '#d4e7d0',
+            'border' => '#6b8f71',
+        ),
         'purple' => array(
             'name' => 'Purple',
             'background' => 'rgb(223, 176, 255)',
             'border' => 'rgb(205, 133, 254)',
+        ),
+        'deep_purple' => array(
+            'name' => 'Deep Purple',
+            'background' => '#d1c4e9',
+            'border' => '#673ab7',
         ),
         'red' => array(
             'name' => 'Red',

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -29,6 +29,14 @@ class ColorModelTest extends Base
         $this->assertEquals($expected, $colorModel->getColorProperties('light_green'));
 
         $expected = array(
+            'name' => 'Dirty Green',
+            'background' => '#d4e7d0',
+            'border' => '#6b8f71',
+        );
+
+        $this->assertEquals($expected, $colorModel->getColorProperties('dirty_green'));
+
+        $expected = array(
             'name' => 'Yellow',
             'background' => 'rgb(245, 247, 196)',
             'border' => 'rgb(223, 227, 45)',
@@ -42,11 +50,11 @@ class ColorModelTest extends Base
         $colorModel = new ColorModel($this->container);
 
         $colors = $colorModel->getList();
-        $this->assertCount(16, $colors);
+        $this->assertCount(18, $colors);
         $this->assertEquals('Yellow', $colors['yellow']);
 
         $colors = $colorModel->getList(true);
-        $this->assertCount(17, $colors);
+        $this->assertCount(18, $colors);
         $this->assertEquals('All colors', $colors['']);
         $this->assertEquals('Yellow', $colors['yellow']);
     }
@@ -68,7 +76,7 @@ class ColorModelTest extends Base
         $colorModel = new ColorModel($this->container);
 
         $colors = $colorModel->getDefaultColors();
-        $this->assertCount(16, $colors);
+        $this->assertCount(18, $colors);
     }
 
     public function testGetBorderColor()
@@ -91,5 +99,9 @@ class ColorModelTest extends Base
         $this->assertStringStartsWith('.task-board.color-yellow', $css);
         $this->assertStringContainsString('.task-board.color-yellow .task-board-project, .task-board.color-yellow .task-tags .task-tag, .task-summary-container.color-yellow .task-tags .task-tag {background-color: rgb(251, 252, 228);border-color: rgb(223, 227, 45);font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-tag.color-yellow {background-color: rgb(251, 252, 228);border-color: rgb(223, 227, 45);font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: rgb(238, 228, 247);border-color: #673ab7;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: rgb(238, 228, 247);border-color: #673ab7;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-dirty_green .task-board-project, .task-board.color-dirty_green .task-tags .task-tag, .task-summary-container.color-dirty_green .task-tags .task-tag {background-color: rgb(239, 246, 237);border-color: #6b8f71;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-dirty_green {background-color: rgb(239, 246, 237);border-color: #6b8f71;font-weight: bold;}', $css);
     }
 }


### PR DESCRIPTION
## Summary
- add the deep purple color definition so tasks with that palette apply the lighter project and tag styles
- extend the color model unit test expectations to cover the new color output
- add the dirty green color definition with matching lighter project and tag styling assertions

## Testing
- not run (phpunit binary not available in repository)

------
https://chatgpt.com/codex/tasks/task_e_68cc2f2477e88324830038b9990dc475