### PR TITLE
Align deep purple variant styling

### DIFF
--- a/app/Model/ColorModel.php
+++ b/app/Model/ColorModel.php
@@ -46,8 +46,8 @@ class ColorModel extends Base
         ),
         'deep_purple' => array(
             'name' => 'Deep Purple',
-            'background' => '#d1c4e9',
-            'border' => '#673ab7',
+            'background' => '#dfc5fe',
+            'border' => '#dfc5fe',
         ),
         'red' => array(
             'name' => 'Red',
@@ -118,7 +118,7 @@ class ColorModel extends Base
      */
     protected $lighter_shade_overrides = array(
         'purple' => 0.1875,
-        'deep_purple' => 0.1875,
+        'deep_purple' => 0.0,
         'dirty_green' => 0.1875,
     );
 

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -105,9 +105,9 @@ class ColorModelTest extends Base
         $this->assertStringContainsString('.task-board-assignee-tag.color-purple {background-color: rgb(223, 176, 255);border-color: rgb(205, 133, 254);font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-tag.color-green, .task-board-assignee-tag.color-green {background-color: rgb(221, 251, 235);border-color: rgb(74, 227, 113);font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board-assignee-tag.color-green {background-color: rgb(189, 244, 203);border-color: rgb(74, 227, 113);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: rgb(233, 220, 246);border-color: #673ab7;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: rgb(233, 220, 246);border-color: #673ab7;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-deep_purple {background-color: rgb(233, 220, 246);border-color: #673ab7;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: rgb(223, 197, 254);border-color: #dfc5fe;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: rgb(223, 197, 254);border-color: #dfc5fe;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-deep_purple {background-color: rgb(223, 197, 254);border-color: #dfc5fe;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board.color-dirty_green .task-board-project, .task-board.color-dirty_green .task-tags .task-tag, .task-summary-container.color-dirty_green .task-tags .task-tag {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-tag.color-dirty_green {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board-assignee-tag.color-dirty_green {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);


### PR DESCRIPTION
## Summary
- update the deep purple color definition to the lighter #dfc5fe shade
- align the color model unit test expectations with the new palette values
- ensure the generated lighter variant for deep purple uses the requested #dfc5fe tone

## Testing
- ⚠️ `vendor/bin/phpunit tests/units/Model/ColorModelTest.php` *(fails: phpunit binary is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dc8784388324b06bc8fe7dc8f959