### PR TITLE
Convert rgb colors to hex equivalents

### DIFF
--- a/app/Model/ColorModel.php
+++ b/app/Model/ColorModel.php
@@ -21,18 +21,18 @@ class ColorModel extends Base
     protected $default_colors = array(
         'yellow' => array(
             'name' => 'Yellow',
-            'background' => 'rgb(245, 247, 196)',
-            'border' => 'rgb(223, 227, 45)',
+            'background' => '#f5f7c4',
+            'border' => '#dfe32d',
         ),
         'blue' => array(
             'name' => 'Blue',
-            'background' => 'rgb(219, 235, 255)',
-            'border' => 'rgb(168, 207, 255)',
+            'background' => '#dbebff',
+            'border' => '#a8cfff',
         ),
         'green' => array(
             'name' => 'Green',
-            'background' => 'rgb(189, 244, 203)',
-            'border' => 'rgb(74, 227, 113)',
+            'background' => '#bdf4cb',
+            'border' => '#4ae371',
         ),
         'dirty_green' => array(
             'name' => 'Dirty Green',
@@ -41,8 +41,8 @@ class ColorModel extends Base
         ),
         'purple' => array(
             'name' => 'Purple',
-            'background' => 'rgb(223, 176, 255)',
-            'border' => 'rgb(205, 133, 254)',
+            'background' => '#dfb0ff',
+            'border' => '#cd85fe',
         ),
         'deep_purple' => array(
             'name' => 'Deep Purple',
@@ -51,18 +51,18 @@ class ColorModel extends Base
         ),
         'red' => array(
             'name' => 'Red',
-            'background' => 'rgb(255, 187, 187)',
-            'border' => 'rgb(255, 151, 151)',
+            'background' => '#ffbbbb',
+            'border' => '#ff9797',
         ),
         'orange' => array(
             'name' => 'Orange',
-            'background' => 'rgb(255, 215, 179)',
-            'border' => 'rgb(255, 172, 98)',
+            'background' => '#ffd7b3',
+            'border' => '#ffac62',
         ),
         'grey' => array(
             'name' => 'Grey',
-            'background' => 'rgb(238, 238, 238)',
-            'border' => 'rgb(204, 204, 204)',
+            'background' => '#eeeeee',
+            'border' => '#cccccc',
         ),
         'brown' => array(
             'name' => 'Brown',
@@ -326,6 +326,6 @@ class ColorModel extends Base
         }
         unset($component);
 
-        return sprintf('rgb(%d, %d, %d)', $components[0], $components[1], $components[2]);
+        return sprintf('#%02x%02x%02x', $components[0], $components[1], $components[2]);
     }
 }

--- a/app/User/Avatar/LetterAvatarProvider.php
+++ b/app/User/Avatar/LetterAvatarProvider.php
@@ -31,13 +31,12 @@ class LetterAvatarProvider extends Base implements AvatarProviderInterface
     public function render(array $user, $size)
     {
         $rgb = $this->getBackgroundColor($user['name'] ?: $user['username']);
+        $hexColor = sprintf('#%02x%02x%02x', $rgb[0], $rgb[1], $rgb[2]);
         $label = $this->helper->text->e($user['name'] ?: $user['username']);
 
         return sprintf(
-            '<div class="avatar-letter" style="background-color: rgb(%d, %d, %d)" title="%s" role="img" aria-label="%s">%s</div>',
-            $rgb[0],
-            $rgb[1],
-            $rgb[2],
+            '<div class="avatar-letter" style="background-color: %s" title="%s" role="img" aria-label="%s">%s</div>',
+            $hexColor,
             $label,
             $label,
             $label

--- a/assets/css/src/base.css
+++ b/assets/css/src/base.css
@@ -30,8 +30,8 @@ small {
 hr {
     border: 0;
     height: 0;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3)
+    border-top: 1px solid #0000001a;
+    border-bottom: 1px solid #ffffff4d
 }
 
 .page {

--- a/assets/css/src/dropdown.css
+++ b/assets/css/src/dropdown.css
@@ -26,7 +26,7 @@ ul.dropdown-submenu-open {
     background-color: var(--dropdown-background-color);
     border: 1px solid var(--dropdown-border-color);
     border-radius: 3px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15)
+    box-shadow: 0 1px 3px #00000026
 }
 
 .dropdown-submenu-open li {

--- a/assets/css/src/input_addon.css
+++ b/assets/css/src/input_addon.css
@@ -42,7 +42,7 @@
 
 .input-addon-field,
 .input-addon-item {
-    border: 1px solid rgba(147, 128, 108, 0.25);
+    border: 1px solid #93806c40;
     padding: 4px 0.75em
 }
 

--- a/assets/css/src/modal.css
+++ b/assets/css/src/modal.css
@@ -4,7 +4,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.9);
+    background: #000000e6;
     overflow: auto;
     z-index: 100
 }

--- a/assets/css/src/select_dropdown.css
+++ b/assets/css/src/select_dropdown.css
@@ -8,7 +8,7 @@
     list-style: none;
     border: 1px solid var(--dropdown-border-color);
     border-radius: 3px;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    box-shadow: 0 6px 12px #0000002d;
     overflow: scroll
 }
 

--- a/assets/css/src/slideshow.css
+++ b/assets/css/src/slideshow.css
@@ -4,7 +4,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.95);
+    background: #000000f2;
     overflow: auto;
     z-index: 100
 }

--- a/assets/css/src/suggest_menu.css
+++ b/assets/css/src/suggest_menu.css
@@ -8,7 +8,7 @@
     list-style: none;
     border: 1px solid #ccc;
     border-radius: 3px;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175)
+    box-shadow: 0 6px 12px #0000002d
 }
 
 .suggest-menu-item {

--- a/assets/css/src/table_drag_and_drop.css
+++ b/assets/css/src/table_drag_and_drop.css
@@ -10,7 +10,7 @@
 tr.draggable-item-selected {
     background: var(--draggable-item-selected-background-color);
     border: 2px solid var(--draggable-item-selected-border-color);
-    box-shadow: 4px 2px 10px -4px rgba(0, 0, 0, 0.55)
+    box-shadow: 4px 2px 10px -4px #0000008c
 }
 
 tr.draggable-item-selected td {

--- a/assets/css/src/themes/auto.css
+++ b/assets/css/src/themes/auto.css
@@ -87,7 +87,7 @@
     --dropdown-border-color: #b2b2b2;
     --dropdown-li-border-color: #f8f8f8;
 
-    --input-addon-background-color: rgba(147, 128, 108, 0.1);
+    --input-addon-background-color: #93806c1a;
     --input-addon-color: #666;
 
     --views-background-color: #fafafa;
@@ -95,8 +95,8 @@
     --views-active-color: #000;
 
     --input-focus-color: #000;
-    --input-focus-border-color: rgba(82, 168, 236, 0.8);
-    --input-focus-shadow-color: rgba(82, 168, 236, 0.6);
+    --input-focus-border-color: #52a8eccc;
+    --input-focus-shadow-color: #52a8ec99;
     --input-background-color: #fff;
     --input-border-color: #ccc;
     --input-placeholder-color: #dedede;
@@ -195,7 +195,7 @@ html {
 
         --table-header-background-color: #1a1a1a;
         --table-nth-background-color: #2d2c2c;
-        --table-border-color: rgba(147, 128, 108, 0.25);
+        --table-border-color: #93806c40;
 
         --avatar-color-letter: #fff;
 
@@ -208,30 +208,30 @@ html {
 
         --board-task-limit-color: #DF5353;
 
-        --table-list-header-border-color: rgba(147, 128, 108, 0.25);
-        --table-list-header-background-color: rgb(59, 59, 59);
+        --table-list-header-border-color: #93806c40;
+        --table-list-header-background-color: #3b3b3b;
         --table-list-nth-background-color: #2d2c2c;
-        --table-list-border-color: rgba(147, 128, 108, 0.25);
-        --table-list-row-hover-border-color: rgba(147, 128, 108, 0.25);
+        --table-list-border-color: #93806c40;
+        --table-list-row-hover-border-color: #93806c40;
         --table-list-row-background-color: #434343;
 
-        --sidebar-border-color: rgba(147, 128, 108, 0.25);
+        --sidebar-border-color: #93806c40;
 
         --dropdown-background-color: #222;
         --dropdown-border-color: #000;
         --dropdown-li-border-color: #555;
 
         --input-addon-background-color: #1a1a1a;
-        --input-addon-color: rgba(147, 128, 108, 0.25);
+        --input-addon-color: #93806c40;
 
         --views-background-color: #1a1a1a;
-        --views-border-color: rgba(147, 128, 108, 0.25);
+        --views-border-color: #93806c40;
         --views-active-color: #949494;
 
         --input-focus-color: #e6edf3;
-        --input-focus-border-color: rgba(82, 168, 236, 0.8);
-        --input-focus-shadow-color: rgba(82, 168, 236, 0.6);
-        --input-background-color: rgb(59, 59, 59);
+        --input-focus-border-color: #52a8eccc;
+        --input-focus-shadow-color: #52a8ec99;
+        --input-background-color: #3b3b3b;
         --input-border-color: #777575;
         --input-placeholder-color: #666;
 

--- a/assets/css/src/themes/dark.css
+++ b/assets/css/src/themes/dark.css
@@ -61,7 +61,7 @@
 
     --table-header-background-color: #1a1a1a;
     --table-nth-background-color: #2d2c2c;
-    --table-border-color: rgba(147, 128, 108, 0.25);
+    --table-border-color: #93806c40;
 
     --avatar-color-letter: #fff;
 
@@ -74,30 +74,30 @@
 
     --board-task-limit-color: #DF5353;
 
-    --table-list-header-border-color: rgba(147, 128, 108, 0.25);
-    --table-list-header-background-color: rgb(59, 59, 59);
+    --table-list-header-border-color: #93806c40;
+    --table-list-header-background-color: #3b3b3b;
     --table-list-nth-background-color: #2d2c2c;
-    --table-list-border-color: rgba(147, 128, 108, 0.25);
-    --table-list-row-hover-border-color: rgba(147, 128, 108, 0.25);
+    --table-list-border-color: #93806c40;
+    --table-list-row-hover-border-color: #93806c40;
     --table-list-row-background-color: #434343;
 
-    --sidebar-border-color: rgba(147, 128, 108, 0.25);
+    --sidebar-border-color: #93806c40;
 
     --dropdown-background-color: #222;
     --dropdown-border-color: #000;
     --dropdown-li-border-color: #555;
 
     --input-addon-background-color: #1a1a1a;
-    --input-addon-color: rgba(147, 128, 108, 0.25);
+    --input-addon-color: #93806c40;
 
     --views-background-color: #1a1a1a;
-    --views-border-color: rgba(147, 128, 108, 0.25);
+    --views-border-color: #93806c40;
     --views-active-color: #949494;
 
     --input-focus-color: #e6edf3;
-    --input-focus-border-color: rgba(82, 168, 236, 0.8);
-    --input-focus-shadow-color: rgba(82, 168, 236, 0.6);
-    --input-background-color: rgb(59, 59, 59);
+    --input-focus-border-color: #52a8eccc;
+    --input-focus-shadow-color: #52a8ec99;
+    --input-background-color: #3b3b3b;
     --input-border-color: #777575;
     --input-placeholder-color: #666;
 

--- a/assets/css/src/themes/light.css
+++ b/assets/css/src/themes/light.css
@@ -87,7 +87,7 @@
     --dropdown-border-color: #b2b2b2;
     --dropdown-li-border-color: #f8f8f8;
 
-    --input-addon-background-color: rgba(147, 128, 108, 0.1);
+    --input-addon-background-color: #93806c1a;
     --input-addon-color: #666;
 
     --views-background-color: #fafafa;
@@ -95,8 +95,8 @@
     --views-active-color: #000;
 
     --input-focus-color: #000;
-    --input-focus-border-color: rgba(82, 168, 236, 0.8);
-    --input-focus-shadow-color: rgba(82, 168, 236, 0.6);
+    --input-focus-border-color: #52a8eccc;
+    --input-focus-shadow-color: #52a8ec99;
     --input-background-color: #fff;
     --input-border-color: #ccc;
     --input-placeholder-color: #dedede;

--- a/assets/css/src/thumbnails.css
+++ b/assets/css/src/thumbnails.css
@@ -14,7 +14,7 @@
     border: 1px solid #efefef;
     border-radius: 5px;
     margin-bottom: 20px;
-    box-shadow: 4px 2px 10px -6px rgba(0, 0, 0, 0.55);
+    box-shadow: 4px 2px 10px -6px #0000008c;
     margin-right: 15px
 }
 

--- a/plugins/Oxygen/Assets/css/oxygen.css
+++ b/plugins/Oxygen/Assets/css/oxygen.css
@@ -18,8 +18,8 @@ a{
 	color:#336699;
 }
 div.task-board-recent {
-	box-shadow: none;
-	border-bottom: 6px solid rgba(0, 0, 0, 0.3);
+        box-shadow: none;
+        border-bottom: 6px solid #0000004d;
 }
 div.ganttview-vtheader-series-name {
 	padding: 0 6px;
@@ -29,7 +29,7 @@ th,td {
 }
 header {
         border-bottom: none;
-        box-shadow: 0px 1px 3px 0 rgba(46,61,73,.12);
+        box-shadow: 0px 1px 3px 0 #2e3d491f;
         padding: 15px 10px;
         margin-bottom: 15px;
 }
@@ -71,11 +71,11 @@ label {
 	margin-top: 18px;
 }
 .task-board {
-	margin-bottom: 8px;
-	padding: 12px;
-	border-radius: 6px;
-	box-shadow: 0px 5px 5px 0 rgba(46,61,73,.12);
-	border: none;
+        margin-bottom: 8px;
+        padding: 12px;
+        border-radius: 6px;
+        box-shadow: 0px 5px 5px 0 #2e3d491f;
+        border: none;
 }
 .task-board-title {
 	font-size: 1.25em;
@@ -86,10 +86,10 @@ label {
 	margin-bottom: 20px;
 }
 .task-show-details h2 {
-	background-color: rgba(0, 0, 0, 0.3);
-	padding: 20px;
-	border-radius: 8px 8px 0 0;
-	color: #fff;
+        background-color: #0000004d;
+        padding: 20px;
+        border-radius: 8px 8px 0 0;
+        color: #fff;
 }
 .task-show-details ul {
 	padding: 20px;
@@ -268,23 +268,23 @@ a i.web-notification-icon {
 	border-radius: 5px;
 }
 .sidebar {
-	background-color: #f7f7f7;
-	padding: 7px;
-	border-radius: 7px;
-	border-left: 2px solid #e9e9e9;
-	box-shadow: 1px 0px 7px 0 rgba(46,61,73,.12);
+        background-color: #f7f7f7;
+        padding: 7px;
+        border-radius: 7px;
+        border-left: 2px solid #e9e9e9;
+        box-shadow: 1px 0px 7px 0 #2e3d491f;
 }
 input[type="number"]:focus, input[type="date"]:focus, input[type="email"]:focus, input[type="password"]:focus, input[type="text"]:focus {
-	color: #000;
-	border-color: #336699;
-	outline: 0;
-	box-shadow: 0 0 0 0.2rem rgba(222,222,222,0.25);
+        color: #000;
+        border-color: #336699;
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem #dedede40;
 }
 textarea:focus {
-	color: #000;
-	border-color: #336699;
-	outline: 0;
-	box-shadow: 0 0 0 0.2rem rgba(222,222,222,0.25);
+        color: #000;
+        border-color: #336699;
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem #dedede40;
 }
 input[type="number"], input[type="date"], input[type="email"], input[type="password"], input[type="text"]:not(.input-addon-field) {
 	padding:3px;

--- a/plugins/Oxygen/Assets/css/prism.css
+++ b/plugins/Oxygen/Assets/css/prism.css
@@ -10,7 +10,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #f8f8f2;
 	background: none;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+    text-shadow: 0 1px #0000004d;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
 	white-space: pre;
@@ -209,8 +209,8 @@ div.code-toolbar > .toolbar span {
 	font-size: .8em;
 	padding: 0 .5em;
 	background: #f5f2f0;
-	background: rgba(224, 224, 224, 0.2);
-	box-shadow: 0 2px 0 0 rgba(0,0,0,0.2);
+    background: #e0e0e033;
+    box-shadow: 0 2px 0 0 #00000033;
 	border-radius: .5em;
 }
 

--- a/tests/units/Formatter/UserMentionFormatterTest.php
+++ b/tests/units/Formatter/UserMentionFormatterTest.php
@@ -34,7 +34,7 @@ class UserMentionFormatterTest extends Base
             ),
             array(
                 'value' => 'somebody',
-                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: rgb(191, 210, 121)" title="somebody" role="img" aria-label="somebody">somebody</div></div> somebody',
+                'html' => '<div class="avatar avatar-20 avatar-inline"><div class="avatar-letter" style="background-color: #bfd279" title="somebody" role="img" aria-label="somebody">somebody</div></div> somebody',
             ),
         );
 

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -38,8 +38,8 @@ class ColorModelTest extends Base
 
         $expected = array(
             'name' => 'Yellow',
-            'background' => 'rgb(245, 247, 196)',
-            'border' => 'rgb(223, 227, 45)',
+            'background' => '#f5f7c4',
+            'border' => '#dfe32d',
         );
 
         $this->assertEquals($expected, $colorModel->getColorProperties('foobar'));
@@ -82,13 +82,13 @@ class ColorModelTest extends Base
     public function testGetBorderColor()
     {
         $colorModel = new ColorModel($this->container);
-        $this->assertEquals('rgb(74, 227, 113)', $colorModel->getBorderColor('green'));
+        $this->assertEquals('#4ae371', $colorModel->getBorderColor('green'));
     }
 
     public function testGetBackgroundColor()
     {
         $colorModel = new ColorModel($this->container);
-        $this->assertEquals('rgb(189, 244, 203)', $colorModel->getBackgroundColor('green'));
+        $this->assertEquals('#bdf4cb', $colorModel->getBackgroundColor('green'));
     }
 
     public function testGetCss()
@@ -97,20 +97,20 @@ class ColorModelTest extends Base
         $css = $colorModel->getCss();
 
         $this->assertStringStartsWith('.task-board.color-yellow', $css);
-        $this->assertStringContainsString('.task-board.color-yellow .task-board-project, .task-board.color-yellow .task-tags .task-tag, .task-summary-container.color-yellow .task-tags .task-tag {background-color: rgb(251, 252, 228);border-color: rgb(223, 227, 45);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-yellow {background-color: rgb(251, 252, 228);border-color: rgb(223, 227, 45);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-yellow {background-color: rgb(251, 252, 228);border-color: rgb(223, 227, 45);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board.color-purple .task-board-project, .task-board.color-purple .task-tags .task-tag, .task-summary-container.color-purple .task-tags .task-tag {background-color: rgb(242, 200, 255);border-color: rgb(205, 133, 254);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-purple, .task-board-assignee-tag.color-purple {background-color: rgb(242, 200, 255);border-color: rgb(205, 133, 254);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-purple {background-color: rgb(223, 176, 255);border-color: rgb(205, 133, 254);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-green, .task-board-assignee-tag.color-green {background-color: rgb(221, 251, 235);border-color: rgb(74, 227, 113);font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-green {background-color: rgb(189, 244, 203);border-color: rgb(74, 227, 113);font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-yellow .task-board-project, .task-board.color-yellow .task-tags .task-tag, .task-summary-container.color-yellow .task-tags .task-tag {background-color: #fbfce4;border-color: #dfe32d;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-yellow {background-color: #fbfce4;border-color: #dfe32d;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-yellow {background-color: #f5f7c4;border-color: #dfe32d;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-purple .task-board-project, .task-board.color-purple .task-tags .task-tag, .task-summary-container.color-purple .task-tags .task-tag {background-color: #f2c8ff;border-color: #cd85fe;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-purple, .task-board-assignee-tag.color-purple {background-color: #f2c8ff;border-color: #cd85fe;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-purple {background-color: #dfb0ff;border-color: #cd85fe;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-green, .task-board-assignee-tag.color-green {background-color: #ddfbeb;border-color: #4ae371;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-green {background-color: #bdf4cb;border-color: #4ae371;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board.color-deep_purple, .task-summary-container.color-deep_purple, .color-picker-square.color-deep_purple, .task-board-category.color-deep_purple, .table-list-category.color-deep_purple {background-color: transparent;border-color: #610288;}', $css);
-        $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: rgb(223, 197, 254);border-color: #610288;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: rgb(223, 197, 254);border-color: #610288;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-deep_purple {background-color: rgb(223, 197, 254);border-color: #610288;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board.color-dirty_green .task-board-project, .task-board.color-dirty_green .task-tags .task-tag, .task-summary-container.color-dirty_green .task-tags .task-tag {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-tag.color-dirty_green {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);
-        $this->assertStringContainsString('.task-board-assignee-tag.color-dirty_green {background-color: rgb(236, 245, 232);border-color: #6b8f71;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-deep_purple {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board.color-dirty_green .task-board-project, .task-board.color-dirty_green .task-tags .task-tag, .task-summary-container.color-dirty_green .task-tags .task-tag {background-color: #ecf5e8;border-color: #6b8f71;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-tag.color-dirty_green {background-color: #ecf5e8;border-color: #6b8f71;font-weight: bold;}', $css);
+        $this->assertStringContainsString('.task-board-assignee-tag.color-dirty_green {background-color: #ecf5e8;border-color: #6b8f71;font-weight: bold;}', $css);
     }
 }

--- a/tests/units/User/Avatar/LetterAvatarProviderTest.php
+++ b/tests/units/User/Avatar/LetterAvatarProviderTest.php
@@ -24,7 +24,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'Kanboard Admin', 'username' => 'bob', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(120, 83, 58)" title="Kanboard Admin" role="img" aria-label="Kanboard Admin">Kanboard Admin</div>';
+        $expected = '<div class="avatar-letter" style="background-color: #78533a" title="Kanboard Admin" role="img" aria-label="Kanboard Admin">Kanboard Admin</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -32,7 +32,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => '', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(134, 45, 132)" title="admin" role="img" aria-label="admin">admin</div>';
+        $expected = '<div class="avatar-letter" style="background-color: #862d84" title="admin" role="img" aria-label="admin">admin</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 
@@ -40,7 +40,7 @@ class LetterAvatarProviderTest extends Base
     {
         $provider = new LetterAvatarProvider($this->container);
         $user = array('id' => 123, 'name' => 'ü', 'username' => 'admin', 'email' => '');
-        $expected = '<div class="avatar-letter" style="background-color: rgb(62, 147, 31)" title="ü" role="img" aria-label="ü">ü</div>';
+        $expected = '<div class="avatar-letter" style="background-color: #3e931f" title="ü" role="img" aria-label="ü">ü</div>';
         $this->assertEquals($expected, $provider->render($user, 48));
     }
 }


### PR DESCRIPTION
## Summary
- replace rgb/rgba color definitions across the application with equivalent hex values
- update color utilities and avatar rendering to emit hex strings
- adjust unit tests to assert the new hex-based color output

## Testing
- not run (phpunit not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d76c709e14832497ddaa4ed627ba60