### PR TITLE
Adjust deep purple card background color

### DIFF
--- a/app/Model/ColorModel.php
+++ b/app/Model/ColorModel.php
@@ -272,6 +272,11 @@ class ColorModel extends Base
                 $buffer .= 'font-weight: bold;';
                 $buffer .= '}';
             }
+            if ($color === 'deep_purple') {
+                $buffer .= '.task-board.color-'.$color.' {';
+                $buffer .= 'background-color: #b180d091;';
+                $buffer .= '}';
+            }
             $buffer .= '.task-board.color-'.$color.' .task-board-project, .task-board.color-'.$color.' .task-tags .task-tag, .task-summary-container.color-'.$color.' .task-tags .task-tag {';
             $buffer .= 'background-color: '.$lighterBackground.';';
             $buffer .= 'border-color: '.$values['border'].';';

--- a/tests/units/Model/ColorModelTest.php
+++ b/tests/units/Model/ColorModelTest.php
@@ -106,6 +106,7 @@ class ColorModelTest extends Base
         $this->assertStringContainsString('.task-tag.color-green, .task-board-assignee-tag.color-green {background-color: #ddfbeb;border-color: #4ae371;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board-assignee-tag.color-green {background-color: #bdf4cb;border-color: #4ae371;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board.color-deep_purple, .task-summary-container.color-deep_purple, .color-picker-square.color-deep_purple, .task-board-category.color-deep_purple, .table-list-category.color-deep_purple {background-color: transparent;border-color: #610288;}', $css);
+        $this->assertStringContainsString('.task-board.color-deep_purple {background-color: #b180d091;}', $css);
         $this->assertStringContainsString('.task-board.color-deep_purple .task-board-project, .task-board.color-deep_purple .task-tags .task-tag, .task-summary-container.color-deep_purple .task-tags .task-tag {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-tag.color-deep_purple {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);
         $this->assertStringContainsString('.task-board-assignee-tag.color-deep_purple {background-color: #dfc5fe;border-color: #610288;font-weight: bold;}', $css);


### PR DESCRIPTION
## Summary
- update the generated CSS so deep purple task cards use the new background color while related elements stay unchanged
- extend the color model unit test to cover the new deep purple card styling rule

## Testing
- ❌ `vendor/bin/phpunit tests/units/Model/ColorModelTest.php` *(fails: phpunit binary is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d77094a48c8324955ac98b8ff3ce54