### PR TITLE
Reorder header structure and adjust logo sizing

### DIFF
--- a/app/Template/header.php
+++ b/app/Template/header.php
@@ -1,19 +1,23 @@
-<?php $_title = $this->render('header/title', array(
+<?php
+$_logo = $this->render('header/logo');
+$_title = $this->render('header/title', array(
     'project' => isset($project) ? $project : null,
     'task' => isset($task) ? $task : null,
     'description' => isset($description) ? $description : null,
     'title' => $title,
-)) ?>
+));
 
-<?php $_top_right_corner = implode('&nbsp;', array(
-        $this->render('header/user_notifications'),
-        $this->render('header/creation_dropdown'),
-        $this->render('header/user_dropdown')
-    )) ?>
+$_menu_items = array_filter(array(
+    $_title,
+    $this->render('header/user_notifications'),
+    $this->render('header/creation_dropdown'),
+    $this->render('header/user_dropdown'),
+));
+?>
 
 <header>
     <div class="title-container">
-        <?= $_title ?>
+        <?= $_logo ?>
     </div>
     <div class="board-selector-container">
         <?php if (! empty($board_selector)): ?>
@@ -21,6 +25,6 @@
         <?php endif ?>
     </div>
     <div class="menus-container">
-        <?= $_top_right_corner ?>
+        <?= implode('&nbsp;', $_menu_items) ?>
     </div>
 </header>

--- a/app/Template/header/logo.php
+++ b/app/Template/header/logo.php
@@ -1,0 +1,12 @@
+<?php
+$logoImage = sprintf(
+    '<img src="%sassets/img/logo.svg" class="logo-image" alt="%s">',
+    $this->url->dir(),
+    $this->text->e(t('Kanboard'))
+);
+?>
+<h1>
+    <span class="logo">
+        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
+    </span>
+</h1>

--- a/app/Template/header/title.php
+++ b/app/Template/header/title.php
@@ -1,25 +1,15 @@
 <?php
-$logoImage = sprintf(
-    '<img src="%sassets/img/logo.svg" class="logo-image" alt="%s">',
-    $this->url->dir(),
-    $this->text->e(t('Kanboard'))
-);
 ?>
-<h1>
-    <span class="logo">
-        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
-    </span>
-    <span class="title">
-        <?php if (! empty($project) && ! empty($task)): ?>
-            <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
-        <?php else: ?>
-            <?= $this->text->e($title) ?>
-            <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
-              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
-            <?php endif ?>
+<span class="title">
+    <?php if (! empty($project) && ! empty($task)): ?>
+        <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
+    <?php else: ?>
+        <?= $this->text->e($title) ?>
+        <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
+            (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
         <?php endif ?>
-    </span>
-    <?php if (! empty($description)): ?>
-        <?= $this->app->tooltipHTML($description) ?>
     <?php endif ?>
-</h1>
+</span>
+<?php if (! empty($description)): ?>
+    <?= $this->app->tooltipHTML($description) ?>
+<?php endif ?>

--- a/assets/css/src/header.css
+++ b/assets/css/src/header.css
@@ -9,28 +9,28 @@ header {
 
 header .title-container {
     flex: 1;
-    min-width: 300px
+    min-width: 120px;
 }
 
 @media (max-width: 480px) {
     header .title-container {
-        order: 3
+        order: 3;
     }
 }
 
 header .board-selector-container {
     min-width: 320px;
     display: flex;
-    align-items: center
+    align-items: center;
 }
 
 @media (max-width: 480px) {
     header .board-selector-container {
         order: 2;
-        min-width: 300px
+        min-width: 300px;
     }
     header .board-selector-container input[type=text] {
-        max-width: 280px
+        max-width: 280px;
     }
 }
 
@@ -38,24 +38,26 @@ header .menus-container {
     min-width: 120px;
     display: flex;
     align-items: center;
-    justify-content: flex-end
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 12px;
 }
 
 @media (max-width: 480px) {
     header .menus-container {
         order: 1;
         margin-bottom: 5px;
-        margin-left: auto
+        margin-left: auto;
     }
 }
 
 header h1 {
-    font-size: 1.5em
+    font-size: 1.5em;
 }
 
-header h1 .tooltip {
+header .menus-container .tooltip {
     opacity: 0.3;
-    font-size: 0.7em
+    font-size: 0.7em;
 }
 
 a i.web-notification-icon {
@@ -64,5 +66,5 @@ a i.web-notification-icon {
 
 a i.web-notification-icon:focus,
 a i.web-notification-icon:hover {
-    color: #000
+    color: #000;
 }

--- a/assets/css/src/logo.css
+++ b/assets/css/src/logo.css
@@ -13,6 +13,6 @@
 
 .logo-image {
     display: block;
-    height: 32px;
+    height: 75px;
     width: auto;
 }

--- a/plugins/Oxygen/Assets/css/oxygen.css
+++ b/plugins/Oxygen/Assets/css/oxygen.css
@@ -41,20 +41,19 @@ header {
 header .title-container h1 {
         display: flex;
         align-items: center;
-        gap: 12px;
-        flex-wrap: wrap;
-}
-header .title-container h1 .logo,
-header .title-container h1 .title {
-        display: flex;
-        align-items: center;
 }
 header .title-container h1 .logo {
         flex-shrink: 0;
 }
-header .title-container h1 .title {
-        gap: 0.4em;
-        min-width: 0;
+header .menus-container {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+}
+header .menus-container .title {
+        font-weight: 600;
 }
 .header img {
   float: left;

--- a/plugins/Oxygen/Plugin.php
+++ b/plugins/Oxygen/Plugin.php
@@ -11,16 +11,17 @@ class Plugin extends Base
     {
         global $themeOxygenConfig;
 
-        if (file_exists('plugins/Oxygen/config.php')) 
+        if (file_exists('plugins/Oxygen/config.php'))
         {
             require_once('plugins/Oxygen/config.php');
         }
 
-        if (isset($themeOxygenConfig['logo'])) 
+        if (isset($themeOxygenConfig['logo']))
         {
+            $this->template->setTemplateOverride('header/logo', 'Oxygen:layout/header/logo');
             $this->template->setTemplateOverride('header/title', 'Oxygen:layout/header/title');
         }
-		
+
         $this->hook->on("template:layout:css", array("template" => "plugins/Oxygen/Assets/css/oxygen.css"));
 
         $this->hook->on("template:layout:css", array("template" => "plugins/Oxygen/Assets/css/prism.css"));

--- a/plugins/Oxygen/Template/header/logo.php
+++ b/plugins/Oxygen/Template/header/logo.php
@@ -1,0 +1,19 @@
+<?php
+global $themeOxygenConfig;
+
+$logoPath = $this->url->dir() . 'assets/img/logo.svg';
+if (isset($themeOxygenConfig['logo'])) {
+    $logoPath = $this->url->dir() . 'plugins/Oxygen/Assets/images/' . $themeOxygenConfig['logo'];
+}
+
+$logoImage = sprintf(
+    '<img src="%s" class="logo-image" alt="%s">',
+    $logoPath,
+    $this->text->e(t('Kanboard'))
+);
+?>
+<h1>
+    <span class="logo">
+        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
+    </span>
+</h1>

--- a/plugins/Oxygen/Template/header/title.php
+++ b/plugins/Oxygen/Template/header/title.php
@@ -1,25 +1,15 @@
 <?php
-$logoImage = sprintf(
-    '<img src="%sassets/img/logo.svg" class="logo-image" alt="%s">',
-    $this->url->dir(),
-    $this->text->e(t('Kanboard'))
-);
 ?>
-<h1>
-    <span class="logo">
-        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
-    </span>
-    <span class="title">
-        <?php if (! empty($project) && ! empty($task)): ?>
-            <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
-        <?php else: ?>
-            <?= $this->text->e($title) ?>
-            <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
-              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
-            <?php endif ?>
+<span class="title">
+    <?php if (! empty($project) && ! empty($task)): ?>
+        <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
+    <?php else: ?>
+        <?= $this->text->e($title) ?>
+        <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
+            (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
         <?php endif ?>
-    </span>
-    <?php if (! empty($description)): ?>
-        <?= $this->app->tooltipHTML($description) ?>
     <?php endif ?>
-</h1>
+</span>
+<?php if (! empty($description)): ?>
+    <?= $this->app->tooltipHTML($description) ?>
+<?php endif ?>

--- a/plugins/Oxygen/Template/layout/header/logo.php
+++ b/plugins/Oxygen/Template/layout/header/logo.php
@@ -1,0 +1,19 @@
+<?php
+global $themeOxygenConfig;
+
+$logoPath = $this->url->dir() . 'assets/img/logo.svg';
+if (isset($themeOxygenConfig['logo'])) {
+    $logoPath = $this->url->dir() . 'plugins/Oxygen/Assets/images/' . $themeOxygenConfig['logo'];
+}
+
+$logoImage = sprintf(
+    '<img src="%s" class="logo-image" alt="%s">',
+    $logoPath,
+    $this->text->e(t('Kanboard'))
+);
+?>
+<h1>
+    <span class="logo">
+        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
+    </span>
+</h1>

--- a/plugins/Oxygen/Template/layout/header/title.php
+++ b/plugins/Oxygen/Template/layout/header/title.php
@@ -1,25 +1,15 @@
 <?php
-$logoImage = sprintf(
-    '<img src="%sassets/img/logo.svg" class="logo-image" alt="%s">',
-    $this->url->dir(),
-    $this->text->e(t('Kanboard'))
-);
 ?>
-<h1>
-    <span class="logo">
-        <?= $this->url->link($logoImage, 'DashboardController', 'show', array(), false, '', t('Dashboard')) ?>
-    </span>
-    <span class="title">
-        <?php if (! empty($project) && ! empty($task)): ?>
-            <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
-        <?php else: ?>
-            <?= $this->text->e($title) ?>
-            <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
-              (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
-            <?php endif ?>
+<span class="title">
+    <?php if (! empty($project) && ! empty($task)): ?>
+        <?= $this->url->link($this->text->e($project['name']), 'BoardViewController', 'show', array('project_id' => $project['id'])) ?>
+    <?php else: ?>
+        <?= $this->text->e($title) ?>
+        <?php if (! empty($project) && $project['task_limit'] && array_key_exists('nb_active_tasks', $project)): ?>
+            (<span><?= intval($project['nb_active_tasks']) ?></span> / <span title="<?= t('Task limit') ?>"><span class="ui-helper-hidden-accessible"><?= t('Task limit') ?> </span><?= $this->text->e($project['task_limit']) ?></span>)
         <?php endif ?>
-    </span>
-    <?php if (! empty($description)): ?>
-        <?= $this->app->tooltipHTML($description) ?>
     <?php endif ?>
-</h1>
+</span>
+<?php if (! empty($description)): ?>
+    <?= $this->app->tooltipHTML($description) ?>
+<?php endif ?>


### PR DESCRIPTION
## Summary
- split the header markup so the logo renders separately from the title
- move the page title into the right-side menu group and enlarge the logo image
- update the Oxygen theme overrides and styles to match the new header structure

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d774a3e2588324ad54e542f9f68ef2