### PR TITLE
Add compose config for building app from local source

### DIFF
--- a/docker-compose.mysql.source.yml
+++ b/docker-compose.mysql.source.yml
@@ -1,0 +1,48 @@
+# Sample docker-compose file to run Kanboard with MariaDB using the local source tree
+# More information at https://docs.kanboard.org/v1/admin/docker/
+name: kanboardv2-source
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: kanboard/kanboard:source
+    container_name: kanboardv2-source
+    restart: always
+    ports:
+      - "11000:80"
+      - "11001:443"
+    volumes:
+      - data:/var/www/app/data
+      - plugins:/var/www/app/plugins
+      - certs:/etc/nginx/ssl
+    environment:
+      DATABASE_URL: mysql://kanboard:kanboard-secret@db/kanboard
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: mariadb:lts
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: kanboard
+      MYSQL_USER: kanboard
+      MYSQL_PASSWORD: kanboard-secret
+    volumes:
+      - db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+volumes:
+  data:
+    driver: local
+  plugins:
+    driver: local
+  certs:
+    driver: local
+  db:
+    driver: local


### PR DESCRIPTION
## Summary
- add a MySQL docker-compose configuration that builds the Kanboard image from the local source tree
- retain the existing MariaDB service configuration and volumes while building the app service locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd45df33b48324914da91ff7d3a8a1